### PR TITLE
add systemd unit and timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,32 @@ To ensure seamless connectivity, you can configure the macOS app to run automati
 The app will now run automatically every 12,000 seconds and at startup, ensuring uninterrupted connectivity.
 
 ---
+## Automate execution of `wifi_login.sh` on Linux with systemd-timer
+
+1. After setting up credentials in `wifi_login.sh` on line 45 and 46, as root or with sudo execute: 
+
+    ```bash
+    sudo mv wifi_login.sh /usr/local/bin/
+    ```
+2. Move the systemd files to their locations as root or with sudo:
+
+    ```bash
+    sudo mv systemd/wifi_login.service systemd/wifi_login.timer /etc/systemd/system/
+    ```
+
+3. Enable and Start the timer: 
+    ```bash
+    sudo systemctl daemon-reexec
+    sudo systemctl daemon-reload
+    sudo systemctl enable --now wifi_login.timer
+    ```
+    This will start a systemd-timer which will run `wifi_login.sh` every 12,000 seconds starting at boot.
+4. Check status if the timer is running with:
+    ```
+    systemctl list-timers --all
+    ```
+
+---
 
 ## 📜 License
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ The app will now run automatically every 12,000 seconds and at startup, ensuring
     sudo systemctl daemon-reload
     sudo systemctl enable --now wifi_login.timer
     ```
-    This will start a systemd-timer which will run `wifi_login.sh` every 12,000 seconds starting at boot.
+    This will start a systemd-timer which will run `wifi_login.sh` every 2000 seconds starting at boot.
 4. Check status if the timer is running with:
     ```
     systemctl list-timers --all

--- a/systemd/wifi_login.service
+++ b/systemd/wifi_login.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Run wifi_login.sh every 120000 seconds
+Description=Run wifi_login.sh every 2000 seconds
 
 [Service]
 Type=oneshot

--- a/systemd/wifi_login.service
+++ b/systemd/wifi_login.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Run wifi_login.sh every 120000 seconds
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/wifi_login.sh
+
+

--- a/systemd/wifi_login.timer
+++ b/systemd/wifi_login.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Timer to run wifi_login.sh every 12000 seconds
+
+[Timer]
+OnBootSec=12000s
+OnUnitActiveSec=12000s
+Unit=wifi_login.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/wifi_login.timer
+++ b/systemd/wifi_login.timer
@@ -2,8 +2,8 @@
 Description=Timer to run wifi_login.sh every 12000 seconds
 
 [Timer]
-OnBootSec=12000s
-OnUnitActiveSec=12000s
+OnBootSec=2000s
+OnUnitActiveSec=2000s
 Unit=wifi_login.service
 
 [Install]

--- a/wifi_login.sh
+++ b/wifi_login.sh
@@ -43,7 +43,7 @@ if [ "$MATCHED" = true ]; then
 
             # 8. Send login payload
             USERNAME="username" # Change to your username
-            PASSWORD="paswword" # Change to your password
+            PASSWORD="password" # Change to your password
 
             FINAL_RESPONSE=$(curl -s -X POST "$REDIRECT_URL" \
                 -d "4Tredir=" \


### PR DESCRIPTION
These changes add a systemd unit and timer to run `wifi_login.sh` every 2000 seconds. 
Also added instructions on how to set it up in `README.md`